### PR TITLE
Specific looting

### DIFF
--- a/ffxivminion/ffxiv_duty_tasks.lua
+++ b/ffxivminion/ffxiv_duty_tasks.lua
@@ -667,10 +667,25 @@ end
 function e_roll:execute()
 	ml_task_hub:CurrentTask().isComplete = false
 	local loot = Inventory:GetLootList()
+	local dneedlist = {}
+	if(glootlist ~= nil and gjob ~= nil) then
+		for djob, ditem in pairs(glootlist) do
+			if(string.find(gjob,djob) ~= nil) then
+				for n,did in pairs(ditem) do
+					dneedlist[did] =2
+				end
+			else
+				for n,did in pairs(ditem) do
+					dneedlist[did] = 1
+				end		
+			end
+		end
+	end
 	if (loot) then
+
 		if (ml_task_hub:CurrentTask().rollstate == "Need") then
 			for i, e in pairs(loot) do
-				if (gLootOption == "Need" or gLootOption == "Any") then 
+				if ((gLootOption == "Need" or gLootOption == "Any" or dneedlist[e.id]==2) and dneedlist[e.id]~=1) then 
 					d("Attempting to need on loot, result was:"..tostring(e:Need()))
 				end
 			end
@@ -681,7 +696,7 @@ function e_roll:execute()
 		
 		if (ml_task_hub:CurrentTask().rollstate == "Greed") then
 			for i, e in pairs(loot) do
-				if (gLootOption == "Need" or gLootOption == "Greed" or gLootOption == "Any") then 
+				if ((gLootOption == "Need" or gLootOption == "Greed" or gLootOption == "Any" or dneedlist[e.id]==2) and dneedlist[e.id]~=1) then 
 					d("Attempting to greed on loot, result was:"..tostring(e:Greed()))			
 				end
 			end
@@ -696,7 +711,7 @@ function e_roll:execute()
 			end
 			ml_task_hub:CurrentTask().latencyTimer = Now() + 1000
 			ml_task_hub:CurrentTask().rollstate = "Complete"
-		end
+		end	
 	end
 end
 

--- a/ffxivminion/ffxiv_task_duty.lua
+++ b/ffxivminion/ffxiv_task_duty.lua
@@ -541,7 +541,9 @@ function ffxiv_task_duty.UIInit()
 	ffxivminion.Windows.Duty = { id = strings["us"].dutyMode, Name = GetString("dutyMode"), x=50, y=50, width=210, height=300 }
 	ffxivminion.CreateWindow(ffxivminion.Windows.Duty)
 	
-
+	if (Settings.FFXIVMINION.gjob == nil) then
+        Settings.FFXIVMINION.gjob = ""
+    end
 	if (Settings.FFXIVMINION.gLastDutyProfile == nil) then
         Settings.FFXIVMINION.gLastDutyProfile = ""
     end
@@ -571,11 +573,13 @@ function ffxiv_task_duty.UIInit()
     GUI_NewComboBox(winName,"Loot Option",			"gLootOption",				group,"Any,Need,Greed,Pass")
 	GUI_NewCheckbox(winName,"Use Telecast",			"gUseTelecast",group)
 	GUI_NewField(winName,strings[gCurrentLanguage].resetDutyTimer,"gResetDutyTimer",group)
+	GUI_NewField(winName,"desys jobs :","gjob",group)
 	
 	GUI_UnFoldGroup(winName,GetString("status"))
 	ffxivminion.SizeWindow(winName)
 	GUI_WindowVisible(winName, false)
 	
+	gjob = Settings.FFXIVMINION.gjob
 	gLootOption = Settings.FFXIVMINION.gLootOption
 	gUseTelecast = Settings.FFXIVMINION.gUseTelecast
 	gResetDutyTimer = Settings.FFXIVMINION.gResetDutyTimer


### PR DESCRIPTION
A quick modification for specific looting, you have to add on the duty profile something like : (This exemple is for Mog HM)
	["LootList"] = {
		--["GSM"] = {},
		--["BSM"] = {1812,1881,1672,9229},
		--["CRP"] = {2137,1951},
		--["WVR"] = {} ,
		--["LTW"] = {1742}, 
		--["ARM"] = {},
		--["ALC"] = {2207,1992,2208},
	}	

Then, from an user standpoint, if i have a ALC and CRP and want to loot every ALC & CRP items, i have to uncomment the ALC & CRP array on the duty file.
And then on the duty settings, i have to input under duty jobs : ALC,CRP.