### PR TITLE
Sekiseigumi Barracks aetheryte fix

### DIFF
--- a/ffxivminion/ffxiv_common_tasks.lua
+++ b/ffxivminion/ffxiv_common_tasks.lua
@@ -2441,7 +2441,8 @@ function ffxiv_task_moveaethernet:task_complete_eval()
 	
 	if (self.useAethernet and (MIsLoading() or self.startMap ~= Player.localmapid)) then
 		if (MIsLoading()) then
-			local initiatedPos = IsNull(self.initiatedPos,Player.pos)
+			-- Use Player.pos if self.initiatedPos is an empty table
+			local initiatedPos = table.valid(self.initiatedPos) and self.initiatedPos or Player.pos
 			d("Triggering wait for full load-in.")
 			ml_global_information.Await(10000, function () return (Player and not Busy() and math.distance3d(initiatedPos,Player.pos) > 10) end)
 		end


### PR DESCRIPTION
When `self.initiatedPos` is an empty table, [IsNull](https://github.com/MINIONBOTS/FFXIVMinion/blob/fc0793226b05d4516e4f2018f04c1afdd191cc98/ffxivminion/ffxiv_helpers.lua#L5323-L5337) returns an empty table because `{}==nil` is false.  This causes a nil arithmetic error when `math.distance3d` receives this empty table as its first param.

Instead, use `Player.pos` when `self.initiatedPos` is empty according to the minionlib `table.valid` function.

Here's a screenshot of where the issue occurs, and some console output with additional debugging statements showing the relevant vars

![unknown (1)](https://user-images.githubusercontent.com/76016977/105419567-ebc74480-5c0c-11eb-9aea-89bc0fc154f6.png)

```
20:4:24> D = "[MOVEAETHERNET]: Interacting with aetheryte target."
20:4:25> D = "[Kitanoi Functions] - Selecting: Sekiseigumi Barracks."
20:4:25> D = "self.initiatedPos"
20:4:25> D = 
20:4:25> {
20:4:25> }


20:4:25> D = "Player.pos"
20:4:25> D = 
20:4:25> {
20:4:25>     h = -2.680513381958,
20:4:25>     x = 29.034526824951,
20:4:25>     y = 8.0200004577637,
20:4:25>     z = 145.36868286133,
20:4:25> }


20:4:25> D = "Triggering wait for full load-in."
20:4:25> D = "initiatedPos"
20:4:25> D = 
20:4:25> {
20:4:25> }


20:4:31> [Lua Error]: ?:0: attempt to perform arithmetic on a nil value 

20:4:31> Callstack:
20:4:31> [?]:0: 

20:4:31> [[string "C:\MINIONAPP\Bots\FFXIVMinion64\LuaMods\/ffxivminion/ffxiv_common_tasks.lua"]]:2452: 

20:4:31> [?]:0: 

20:4:31> [Lua Error]: ?:0: attempt to perform arithmetic on a nil value ```