### PR TITLE
2002boss

### DIFF
--- a/ffxivminion/ffxiv.lua
+++ b/ffxivminion/ffxiv.lua
@@ -323,6 +323,11 @@ function ml_global_information.MainMenuScreenOnUpdate(event, tickcount)
 				if (not IsControlOpen("TitleDataCenter") and not IsControlOpen("TitleDCWorldMap")) then
 					if (UseControlAction("_TitleMenu", "OpenDataCenter", 0)) then
 						ml_global_information.Await(100, 10000, function()
+							if (UseControlAction("Dialogue", "PressOK", 0)) then
+								ml_global_information.Await(1000, 10000, function()
+									return MGetGameState() == FFXIV.GAMESTATE.MAINMENUSCREEN
+								end)
+							end
 							return IsControlOpen("TitleDataCenter") or IsControlOpen("TitleDCWorldMap")
 						end)
 					end
@@ -333,6 +338,11 @@ function ml_global_information.MainMenuScreenOnUpdate(event, tickcount)
 							if (UseControlAction("TitleDataCenter", "SetDataCenter", (FFXIV_Login_DataCenter - 2)) or UseControlAction("TitleDCWorldMap", "SetDataCenter", (FFXIV_Login_DataCenter - 2))) then
 								login.datacenterSelected = true
 								ml_global_information.Await(100, 10000, function()
+									if (UseControlAction("Dialogue", "PressOK", 0)) then
+										ml_global_information.Await(1000, 10000, function()
+											return MGetGameState() == FFXIV.GAMESTATE.MAINMENUSCREEN
+										end)
+									end
 									return IsControlOpen("TitleDataCenter") or IsControlOpen("TitleDCWorldMap")
 								end)
 							end
@@ -344,6 +354,11 @@ function ml_global_information.MainMenuScreenOnUpdate(event, tickcount)
 					else
 						if (UseControlAction("TitleDataCenter", "Proceed", 0) or UseControlAction("TitleDCWorldMap", "Proceed", 0)) then
 							ml_global_information.Await(1000, 60000, function()
+								if (UseControlAction("Dialogue", "PressOK", 0)) then
+									ml_global_information.Await(1000, 10000, function()
+										return MGetGameState() == FFXIV.GAMESTATE.MAINMENUSCREEN
+									end)
+								end
 								return (table.valid(GetConversationList()) or MGetGameState() ~= FFXIV.GAMESTATE.MAINMENUSCREEN)
 							end)
 							ffxivminion.loginvars.datacenterSelected = false
@@ -355,6 +370,11 @@ function ml_global_information.MainMenuScreenOnUpdate(event, tickcount)
 			if IsControlOpen("_TitleMenu") then
 				if (UseControlAction("_TitleMenu", "Start")) then
 					ml_global_information.Await(1000, 10000, function()
+						if (UseControlAction("Dialogue", "PressOK", 0)) then
+							ml_global_information.Await(1000, 10000, function()
+								return MGetGameState() == FFXIV.GAMESTATE.MAINMENUSCREEN
+							end)
+						end
 						return (table.valid(GetConversationList()) or MGetGameState() ~= FFXIV.GAMESTATE.MAINMENUSCREEN)
 					end)
 				end

--- a/ffxivminion/ffxiv.lua
+++ b/ffxivminion/ffxiv.lua
@@ -442,6 +442,13 @@ function ml_global_information.CharacterSelectScreenOnUpdate(event, tickcount)
 			-- detection for CN language not working, temporarily disable skip
 			if ffxivminion.gameRegion == 2 or string.contains(SelectOKMessage, QueueMessage) == true then
 				d("Waiting In Login Queue...")
+				if (IsControlOpen("Dialogue")) then
+					if (UseControlAction("Dialogue", "PressOK", 0)) then
+						ml_global_information.Await(1000, 10000, function()
+							return MGetGameState() == FFXIV.GAMESTATE.MAINMENUSCREEN
+						end)
+					end
+				end
 				ml_global_information.Await(1000, 2000, function()
 					return (IsControlOpen("SelectOk"))
 				end)


### PR DESCRIPTION
Added below code in a few places. 
Should just confirmed `OK` when 2002 or other error is presented.
Can apply on the title screen, the data center selection, the server selection, or the character select (I believe this is the only place it can happen?).

Also - it probably only applies to English UI? But I have no way to confirm. Do your best to validate this is implemented correct before merging to release build, as I honestly have no idea what I'm doing.

`if (UseControlAction("Dialogue", "PressOK", 0)) then
	ml_global_information.Await(1000, 10000, function()
		return MGetGameState() == FFXIV.GAMESTATE.MAINMENUSCREEN
	end)
end`