### PR TITLE
use the user's setting for avoid AOE in grind modes

### DIFF
--- a/ffxivminion/ffxiv_task_grind.lua
+++ b/ffxivminion/ffxiv_task_grind.lua
@@ -756,7 +756,7 @@ function ffxiv_task_grind.SetModeOptions()
 	gDisableDrawing = Settings.FFXIVMINION.gDisableDrawing
 	Hacks:SkipCutscene(gSkipCutscene)
 	Hacks:Disable3DRendering(gDisableDrawing)
-	gAvoidAOE = true
+	gAvoidAOE = Settings.FFXIVMINION.gAvoidAOE
 	gAutoEquip = Settings.FFXIVMINION.gAutoEquip
 	gGrindEvacAuto = Settings.FFXIVMINION.gGrindEvacAuto
 end

--- a/ffxivminion/ffxiv_task_party.lua
+++ b/ffxivminion/ffxiv_task_party.lua
@@ -158,7 +158,7 @@ function ffxiv_task_party.SetModeOptions()
 	gDisableDrawing = Settings.FFXIVMINION.gDisableDrawing
 	Hacks:SkipCutscene(gSkipCutscene)
 	Hacks:Disable3DRendering(gDisableDrawing)
-	gAvoidAOE = true
+	gAvoidAOE = Settings.FFXIVMINION.gAvoidAOE
 	FFXIV_Common_Profile = "NA"
 	FFXIV_Common_ProfileIndex = 1
 	FFXIV_Common_ProfileList = { "NA" }


### PR DESCRIPTION
Motivated by AOE avoidance preferences for FATE grinding, where it's sometimes better to take/mitigate the the hit than to run off avoiding, possibly outside of the FATE area.

There's more nuance to how to handle open world avoidance, maybe even down to a per AOE basis, and there are addons that provide their own avoidance with more granular control over things like this, so respecting the user setting here just makes it easier for people to run these setups if they prefer.