### PR TITLE
fix: adjust chocobo porter access to be closer

### DIFF
--- a/ffxivminion/ffxiv_nav_data.lua
+++ b/ffxivminion/ffxiv_nav_data.lua
@@ -977,7 +977,7 @@ ffxiv_map_nav.data = {
 		[397] = {
            {id = 397, cost = 5, x = -163.44, y = 2.15, z = -5.51, b = 1011195, i = 1
                 , requires =  {
-                    ["CanUseAetheryte(71)"] = true,
+                    ["QuestCompleted(1583)"] = true,
                 }
             },  
 			{id = 397, cost = 1, x = -186.16, y = 14, z = -57.15, h = -2.27


### PR DESCRIPTION
https://ffxiv.consolegameswiki.com/wiki/Over_the_Wall - the quest

Excerpt from the wiki: 
> The zone line from Coerthas Central Highlands to Foundation will be initially blocked. Should you wish to return to Foundation without using Teleport, the Chocobokeep will grant passage for 5 gil.

Otherwise questing profile cannot proceed if you teleported out of the location