### PR TITLE
Prevent trying to unlock aethernet without acelib

### DIFF
--- a/ffxivminion/ffxiv_common_cne.lua
+++ b/ffxivminion/ffxiv_common_cne.lua
@@ -1909,7 +1909,11 @@ function c_unlockaethernet:evaluate(mapid, pos)
 	
 	if (not table.valid(gotoPos)) then
 		return false
-	end	
+	end
+
+	if AceLib == nil then
+		return false
+	end
 	
 	local gotoDist = Distance3DT(gotoPos,Player.pos)
 	


### PR DESCRIPTION
```lua
	local newTask = ffxiv_task_movetopos.Create()
	newTask.pos = tasks.cGoToPos.pos
	--newTask.cubefilters = gTestNoFly and 1 or 0
	if AceLib == nil then
		newTask.useAethernet = false
	end
	newTask.range = 1
	newTask.remainMounted = false
	ml_task_hub:CurrentTask():AddSubTask(newTask)
```

This code still emits
```
[error]: Error in cause for [UnlockAethernet] [[string "C:\MINIONAPP\Bots\FFXIVMinion64\LuaMods\/ffxivminion/ffxiv_common_cne.lua"]:1916: attempt to index global 'AceLib' (a nil value)]
```

Even though aethernet is intentionally marked not to be used